### PR TITLE
Experiment 6 Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ For the contest the focus was on 4 substrates and their corresponding validation
 | | commons_harvest__closed_1 |
 | | commons_harvest__closed_2 |
 | | commons_harvest__closed_3 |
+| | commons_harvest__private_property_pc_0 |
+| | commons_harvest__private_property_pc_1 |
+| | commons_harvest__private_property_0 |
+| | commons_harvest__private_property_1 |
+| | commons_harvest__open_disable_zapping_0 |
+| | commons_harvest__open_disable_zapping_1 |
 
 
 ## Installation Guidelines

--- a/baselines/train/configs.py
+++ b/baselines/train/configs.py
@@ -40,6 +40,8 @@ SUPPORTED_SCENARIOS = [
     'commons_harvest__private_property_pc_1',
     'commons_harvest__private_property_0',
     'commons_harvest__private_property_1',
+    'commons_harvest__open_disable_zapping_0',
+    'commons_harvest__open_disable_zapping_1',
 ]
 
 IGNORE_KEYS = ['WORLD.RGB', 'INTERACTION_INVENTORIES', 'NUM_OTHERS_WHO_CLEANED_THIS_STEP']
@@ -66,10 +68,12 @@ def get_experiment_config(args, default_config):
     elif args.exp == 'commons_harvest__private_property_pc':
         substrate_name = "commons_harvest__private_property_pc"
     elif args.exp == 'commons_harvest__private_property':
-        substrate_name = "commons_harvest__private_property"    
+        substrate_name = "commons_harvest__private_property"
+    elif args.exp == 'commons_harvest__open_disable_zapping':
+        substrate_name = "commons_harvest__open_disable_zapping"     
     else:
         raise Exception("Please set --exp to be one of ['pd_arena', 'al_harvest', 'clean_up', \
-                        'territory_rooms','daycare','commons_harvest__partnership', 'commons_harvest__open','common_harvest_closed','commons_harvest__private_property_pc', 'commons_harvest__private_property']. Other substrates are not supported.")
+                        'territory_rooms','daycare','commons_harvest__partnership', 'commons_harvest__open','common_harvest_closed','commons_harvest__private_property_pc', 'commons_harvest__private_property','commons_harvest__open_disable_zapping']. Other substrates are not supported.")
 
     # Fetch player roles
     player_roles = substrate.get_config(substrate_name).default_player_roles

--- a/baselines/train/run_ray_train.py
+++ b/baselines/train/run_ray_train.py
@@ -53,7 +53,7 @@ def get_cli_args():
   parser.add_argument(
       "--exp",
       type=str,
-      choices = ['pd_arena','al_harvest','clean_up','territory_rooms','day_care','commons_harvest__partnership','commons_harvest__open','commons_harvest__private_property_pc','commons_harvest__private_property','commons_harvest__closed'],
+      choices = ['pd_arena','al_harvest','clean_up','territory_rooms','day_care','commons_harvest__partnership','commons_harvest__open','commons_harvest__private_property_pc','commons_harvest__private_property','commons_harvest__open_disable_zapping','commons_harvest__closed'],
       default="pd_arena",
       help="Name of the substrate to run",
   )

--- a/meltingpot/configs/substrates/__init__.py
+++ b/meltingpot/configs/substrates/__init__.py
@@ -93,6 +93,7 @@ SUBSTRATES: Set[str] = frozenset({
     'commons_harvest__partnership',
     'commons_harvest__private_property_pc',
     'commons_harvest__private_property',
+    'commons_harvest__open_disable_zapping',
     'coop_mining',
     'daycare',
     'externality_mushrooms__dense',

--- a/meltingpot/configs/substrates/commons_harvest__open_disable_zapping.py
+++ b/meltingpot/configs/substrates/commons_harvest__open_disable_zapping.py
@@ -1,0 +1,587 @@
+# Copyright 2022 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration for Commons Harvest: Open.
+
+Example video: https://youtu.be/lZ-qpPP4BNE
+
+Apples are spread around the map and can be consumed for a reward of 1. Apples
+that have been consumed regrow with a per-step probability that depends on the
+number of uneaten apples in a `L2` norm neighborhood of radius 2 (by default).
+After an apple has been eaten and thus removed, its regrowth probability depends
+on the number of uneaten apples still in its local neighborhood. With standard
+parameters, it the grown rate decreases as the number of uneaten apples in the
+neighborhood decreases and when there are zero uneaten apples in the
+neighborhood then the regrowth rate is zero. As a consequence, a patch of apples
+that collectively doesn't have any nearby apples, can be irrevocably lost if all
+apples in the patch are consumed. Therefore, agents must exercise restraint when
+consuming apples within a patch. Notice that in a single agent situation, there
+is no incentive to collect the last apple in a patch (except near the end of the
+episode). However, in a multi-agent situation, there is an incentive for any
+agent to consume the last apple rather than risk another agent consuming it.
+This creates a tragedy of the commons from which the substrate derives its name.
+
+This mechanism was first described in Janssen et al (2010) and adapted for
+multi-agent reinforcement learning in Perolat et al (2017).
+
+Janssen, M.A., Holahan, R., Lee, A. and Ostrom, E., 2010. Lab experiments for
+the study of social-ecological systems. Science, 328(5978), pp.613-617.
+
+Perolat, J., Leibo, J.Z., Zambaldi, V., Beattie, C., Tuyls, K. and Graepel, T.,
+2017. A multi-agent reinforcement learning model of common-pool
+resource appropriation. In Proceedings of the 31st International Conference on
+Neural Information Processing Systems (pp. 3646-3655).
+"""
+
+from typing import Any, Dict, Mapping, Sequence
+
+from meltingpot.utils.substrates import colors
+from meltingpot.utils.substrates import shapes
+from meltingpot.utils.substrates import specs
+from ml_collections import config_dict
+import numpy as np
+
+# Warning: setting `_ENABLE_DEBUG_OBSERVATIONS = True` may cause slowdown.
+_ENABLE_DEBUG_OBSERVATIONS = False
+
+APPLE_RESPAWN_RADIUS = 2.0
+REGROWTH_PROBABILITIES = [0.0, 0.0025, 0.005, 0.025]
+
+ASCII_MAP = """
+WWWWWWWWWWWWWWWWWWWWWWWW
+WAAA    A      A    AAAW
+WAA    AAA    AAA    AAW
+WA    AAAAA  AAAAA    AW
+W      AAA    AAA      W
+W       A      A       W
+W  A                A  W
+W AAA  Q        Q  AAA W
+WAAAAA            AAAAAW
+W AAA              AAA W
+W  A                A  W
+W                      W
+W                      W
+W                      W
+W  PPPPPPPPPPPPPPPPPP  W
+W PPPPPPPPPPPPPPPPPPPP W
+WPPPPPPPPPPPPPPPPPPPPPPW
+WWWWWWWWWWWWWWWWWWWWWWWW
+"""
+
+# `prefab` determines which prefab game object to use for each `char` in the
+# ascii map.
+CHAR_PREFAB_MAP = {
+    "P": {"type": "all", "list": ["floor", "spawn_point"]},
+    "Q": {"type": "all", "list": ["floor", "inside_spawn_point"]},
+    " ": "floor",
+    "W": "wall",
+    "A": {"type": "all", "list": ["grass", "apple"]},
+}
+
+_COMPASS = ["N", "E", "S", "W"]
+
+FLOOR = {
+    "name": "floor",
+    "components": [
+        {
+            "component": "StateManager",
+            "kwargs": {
+                "initialState": "floor",
+                "stateConfigs": [{
+                    "state": "floor",
+                    "layer": "background",
+                    "sprite": "Floor",
+                }],
+            }
+        },
+        {
+            "component": "Transform",
+        },
+        {
+            "component": "Appearance",
+            "kwargs": {
+                "renderMode": "ascii_shape",
+                "spriteNames": ["Floor"],
+                "spriteShapes": [shapes.GRAINY_FLOOR],
+                "palettes": [{"*": (220, 205, 185, 255),
+                              "+": (210, 195, 175, 255),}],
+                "noRotates": [False]
+            }
+        },
+    ]
+}
+
+GRASS = {
+    "name":
+        "grass",
+    "components": [
+        {
+            "component": "StateManager",
+            "kwargs": {
+                "initialState":
+                    "grass",
+                "stateConfigs": [
+                    {
+                        "state": "grass",
+                        "layer": "background",
+                        "sprite": "Grass"
+                    },
+                    {
+                        "state": "dessicated",
+                        "layer": "background",
+                        "sprite": "Floor"
+                    },
+                ],
+            }
+        },
+        {
+            "component": "Transform",
+        },
+        {
+            "component": "Appearance",
+            "kwargs": {
+                "renderMode": "ascii_shape",
+                "spriteNames": ["Grass", "Floor"],
+                "spriteShapes": [
+                    shapes.GRASS_STRAIGHT, shapes.GRAINY_FLOOR
+                ],
+                "palettes": [{
+                    "*": (158, 194, 101, 255),
+                    "@": (170, 207, 112, 255)
+                }, {
+                    "*": (220, 205, 185, 255),
+                    "+": (210, 195, 175, 255),
+                }],
+                "noRotates": [False, False]
+            }
+        },
+    ]
+}
+
+WALL = {
+    "name": "wall",
+    "components": [
+        {
+            "component": "StateManager",
+            "kwargs": {
+                "initialState": "wall",
+                "stateConfigs": [{
+                    "state": "wall",
+                    "layer": "upperPhysical",
+                    "sprite": "Wall",
+                }],
+            }
+        },
+        {
+            "component": "Transform",
+        },
+        {
+            "component": "Appearance",
+            "kwargs": {
+                "renderMode": "ascii_shape",
+                "spriteNames": ["Wall"],
+                "spriteShapes": [shapes.WALL],
+                "palettes": [{"*": (95, 95, 95, 255),
+                              "&": (100, 100, 100, 255),
+                              "@": (109, 109, 109, 255),
+                              "#": (152, 152, 152, 255)}],
+                "noRotates": [False]
+            }
+        },
+        {
+            "component": "BeamBlocker",
+            "kwargs": {
+                "beamType": "zapHit"
+            }
+        },
+    ]
+}
+
+SPAWN_POINT = {
+    "name": "spawnPoint",
+    "components": [
+        {
+            "component": "StateManager",
+            "kwargs": {
+                "initialState": "spawnPoint",
+                "stateConfigs": [{
+                    "state": "spawnPoint",
+                    "layer": "alternateLogic",
+                    "groups": ["spawnPoints"]
+                }],
+            }
+        },
+        {
+            "component": "Transform",
+        },
+    ]
+}
+
+INSIDE_SPAWN_POINT = {
+    "name": "spawnPoint",
+    "components": [
+        {
+            "component": "StateManager",
+            "kwargs": {
+                "initialState": "spawnPoint",
+                "stateConfigs": [{
+                    "state": "spawnPoint",
+                    "layer": "alternateLogic",
+                    "groups": ["insideSpawnPoints"]
+                }],
+            }
+        },
+        {
+            "component": "Transform",
+        },
+    ]
+}
+
+# Primitive action components.
+# pylint: disable=bad-whitespace
+# pyformat: disable
+NOOP       = {"move": 0, "turn":  0}
+FORWARD    = {"move": 1, "turn":  0}
+STEP_RIGHT = {"move": 2, "turn":  0}
+BACKWARD   = {"move": 3, "turn":  0}
+STEP_LEFT  = {"move": 4, "turn":  0}
+TURN_LEFT  = {"move": 0, "turn": -1}
+TURN_RIGHT = {"move": 0, "turn":  1}
+# pyformat: enable
+# pylint: enable=bad-whitespace
+
+ACTION_SET = (
+    NOOP,
+    FORWARD,
+    BACKWARD,
+    STEP_LEFT,
+    STEP_RIGHT,
+    TURN_LEFT,
+    TURN_RIGHT,
+)
+
+TARGET_SPRITE_SELF = {
+    "name": "Self",
+    "shape": shapes.CUTE_AVATAR,
+    "palette": shapes.get_palette((50, 100, 200)),
+    "noRotate": True,
+}
+
+
+def create_scene():
+  """Creates the scene with the provided args controlling apple regrowth."""
+  scene = {
+      "name": "scene",
+      "components": [
+          {
+              "component": "StateManager",
+              "kwargs": {
+                  "initialState": "scene",
+                  "stateConfigs": [{
+                      "state": "scene",
+                  }],
+              }
+          },
+          {
+              "component": "Transform",
+          },
+          {
+              "component": "Neighborhoods",
+              "kwargs": {}
+          },
+          {
+              "component": "StochasticIntervalEpisodeEnding",
+              "kwargs": {
+                  "minimumFramesPerEpisode": 1000,
+                  "intervalLength": 100,  # Set equal to unroll length.
+                  "probabilityTerminationPerInterval": 0.15
+              }
+          }
+      ]
+  }
+
+  return scene
+
+
+def create_apple_prefab(regrowth_radius=-1.0,  # pylint: disable=dangerous-default-value
+                        regrowth_probabilities=[0, 0.0, 0.0, 0.0]):
+  """Creates the apple prefab with the provided settings."""
+  growth_rate_states = [
+      {
+          "state": "apple",
+          "layer": "lowerPhysical",
+          "sprite": "Apple",
+          "groups": ["apples"]
+      },
+      {
+          "state": "appleWait",
+          "layer": "logic",
+          "sprite": "AppleWait",
+      },
+  ]
+  # Enumerate all possible states for a potential apple. There is one state for
+  # each regrowth rate i.e., number of nearby apples.
+  upper_bound_possible_neighbors = np.floor(np.pi*regrowth_radius**2+1)+1
+  for i in range(int(upper_bound_possible_neighbors)):
+    growth_rate_states.append(dict(state="appleWait_{}".format(i),
+                                   layer="logic",
+                                   groups=["waits_{}".format(i)],
+                                   sprite="AppleWait"))
+
+  apple_prefab = {
+      "name": "apple",
+      "components": [
+          {
+              "component": "StateManager",
+              "kwargs": {
+                  "initialState": "apple",
+                  "stateConfigs": growth_rate_states,
+              }
+          },
+          {
+              "component": "Transform",
+          },
+          {
+              "component": "Appearance",
+              "kwargs": {
+                  "renderMode": "ascii_shape",
+                  "spriteNames": ["Apple", "AppleWait"],
+                  "spriteShapes": [shapes.APPLE, shapes.FILL],
+                  "palettes": [
+                      {"x": (0, 0, 0, 0),
+                       "*": (214, 88, 88, 255),
+                       "#": (194, 79, 79, 255),
+                       "o": (53, 132, 49, 255),
+                       "|": (102, 51, 61, 255)},
+                      {"i": (0, 0, 0, 0)}],
+                  "noRotates": [True, True]
+              }
+          },
+          {
+              "component": "Edible",
+              "kwargs": {
+                  "liveState": "apple",
+                  "waitState": "appleWait",
+                  "rewardForEating": 1.0,
+              }
+          },
+          {
+              "component": "DensityRegrow",
+              "kwargs": {
+                  "liveState": "apple",
+                  "waitState": "appleWait",
+                  "radius": regrowth_radius,
+                  "regrowthProbabilities": regrowth_probabilities,
+              }
+          },
+      ]
+  }
+
+  return apple_prefab
+
+
+def create_prefabs(regrowth_radius=-1.0,
+                   # pylint: disable=dangerous-default-value
+                   regrowth_probabilities=[0, 0.0, 0.0, 0.0]):
+  """Returns a dictionary mapping names to template game objects."""
+  prefabs = {
+      "floor": FLOOR,
+      "grass": GRASS,
+      "wall": WALL,
+      "spawn_point": SPAWN_POINT,
+      "inside_spawn_point": INSIDE_SPAWN_POINT,
+  }
+  prefabs["apple"] = create_apple_prefab(
+      regrowth_radius=regrowth_radius,
+      regrowth_probabilities=regrowth_probabilities)
+  return prefabs
+
+
+def create_avatar_object(player_idx: int,
+                         target_sprite_self: Dict[str, Any],
+                         spawn_group: str) -> Dict[str, Any]:
+  """Create an avatar object that always sees itself as blue."""
+  # Lua is 1-indexed.
+  lua_index = player_idx + 1
+
+  # Setup the self vs other sprite mapping.
+  source_sprite_self = "Avatar" + str(lua_index)
+  custom_sprite_map = {source_sprite_self: target_sprite_self["name"]}
+
+  live_state_name = "player{}".format(lua_index)
+  avatar_object = {
+      "name": "avatar",
+      "components": [
+          {
+              "component": "StateManager",
+              "kwargs": {
+                  "initialState": live_state_name,
+                  "stateConfigs": [
+                      {"state": live_state_name,
+                       "layer": "upperPhysical",
+                       "sprite": source_sprite_self,
+                       "contact": "avatar",
+                       "groups": ["players"]},
+
+                      {"state": "playerWait",
+                       "groups": ["playerWaits"]},
+                  ]
+              }
+          },
+          {
+              "component": "Transform",
+          },
+          {
+              "component": "Appearance",
+              "kwargs": {
+                  "renderMode": "ascii_shape",
+                  "spriteNames": [source_sprite_self],
+                  "spriteShapes": [shapes.CUTE_AVATAR],
+                  "palettes": [shapes.get_palette(
+                      colors.human_readable[player_idx])],
+                  "noRotates": [True]
+              }
+          },
+          {
+              "component": "AdditionalSprites",
+              "kwargs": {
+                  "renderMode": "ascii_shape",
+                  "customSpriteNames": [target_sprite_self["name"]],
+                  "customSpriteShapes": [target_sprite_self["shape"]],
+                  "customPalettes": [target_sprite_self["palette"]],
+                  "customNoRotates": [target_sprite_self["noRotate"]],
+              }
+          },
+          {
+              "component": "Avatar",
+              "kwargs": {
+                  "index": lua_index,
+                  "aliveState": live_state_name,
+                  "waitState": "playerWait",
+                  "speed": 1.0,
+                  "spawnGroup": spawn_group,
+                  "postInitialSpawnGroup": "spawnPoints",
+                  "actionOrder": ["move", "turn"],
+                  "actionSpec": {
+                      "move": {"default": 0, "min": 0, "max": len(_COMPASS)},
+                      "turn": {"default": 0, "min": -1, "max": 1},
+                  },
+                  "view": {
+                      "left": 5,
+                      "right": 5,
+                      "forward": 9,
+                      "backward": 1,
+                      "centered": False
+                  },
+                  "spriteMap": custom_sprite_map,
+              }
+          },
+          {
+              "component": "Zapper",
+              "kwargs": {
+                  "cooldownTime": 2,
+                  "beamLength": 3,
+                  "beamRadius": 1,
+                  "framesTillRespawn": 4,
+                  "penaltyForBeingZapped": 0,
+                  "rewardForZapping": 0,
+              }
+          },
+          {
+              "component": "ReadyToShootObservation",
+          },
+      ]
+  }
+  if _ENABLE_DEBUG_OBSERVATIONS:
+    avatar_object["components"].append({
+        "component": "LocationObserver",
+        "kwargs": {"objectIsAvatar": True, "alsoReportOrientation": True},
+    })
+
+  return avatar_object
+
+
+def create_avatar_objects(num_players):
+  """Returns list of avatar objects of length 'num_players'."""
+  avatar_objects = []
+  for player_idx in range(0, num_players):
+    spawn_group = "spawnPoints"
+    if player_idx < 2:
+      # The first two player slots always spawn closer to the apples.
+      spawn_group = "insideSpawnPoints"
+
+    game_object = create_avatar_object(player_idx,
+                                       TARGET_SPRITE_SELF,
+                                       spawn_group=spawn_group)
+    avatar_objects.append(game_object)
+
+  return avatar_objects
+
+
+def get_config():
+  """Default configuration for training on the commons_harvest level."""
+  config = config_dict.ConfigDict()
+
+  # Action set configuration.
+  config.action_set = ACTION_SET
+  # Observation format configuration.
+  config.individual_observation_names = [
+      "RGB",
+      "READY_TO_SHOOT",
+  ]
+  config.global_observation_names = [
+      "WORLD.RGB",
+  ]
+
+  # The specs of the environment (from a single-agent perspective).
+  config.action_spec = specs.action(len(ACTION_SET))
+  config.timestep_spec = specs.timestep({
+      "RGB": specs.OBSERVATION["RGB"],
+      "READY_TO_SHOOT": specs.OBSERVATION["READY_TO_SHOOT"],
+      # Debug only (do not use the following observations in policies).
+      "WORLD.RGB": specs.rgb(144, 192),
+  })
+
+  # The roles assigned to each player.
+  config.valid_roles = frozenset({"default"})
+  config.default_player_roles = ("default",) * 7
+
+  return config
+
+
+def build(
+    roles: Sequence[str],
+    config: config_dict.ConfigDict,
+) -> Mapping[str, Any]:
+  """Build substrate definition given player roles."""
+  del config
+  num_players = len(roles)
+  # Build the rest of the substrate definition.
+  substrate_definition = dict(
+      levelName="commons_harvest",
+      levelDirectory="meltingpot/lua/levels",
+      numPlayers=num_players,
+      # Define upper bound of episode length since episodes end stochastically.
+      maxEpisodeLengthFrames=5000,
+      spriteSize=8,
+      topology="BOUNDED",  # Choose from ["BOUNDED", "TORUS"],
+      simulation={
+          "map": ASCII_MAP,
+          "gameObjects": create_avatar_objects(num_players),
+          "prefabs": create_prefabs(APPLE_RESPAWN_RADIUS,
+                                    REGROWTH_PROBABILITIES),
+          "charPrefabMap": CHAR_PREFAB_MAP,
+          "scene": create_scene(),
+      },
+  )
+  return substrate_definition


### PR DESCRIPTION
### Experiment 1 Implementation
The following PR implements experiment 6 , removing ZAP action.

- `commons_harvest__open_disable_zapping.py`: variation from commons__harvest_open in which we remove the FIRE_ZAP action .


Scripts modified
`__init__.py in` meltingpot>substrates : this basically registers a new substrate
`configs.py` : add substrates
`run_ray_train.py` : flags and substrates

Test.
It has been evaluated in evaluate.py and made some videos shared in slack, but to be sure it would be nice if you could double check this in python via `python run_ray_train.py --exp commons_harvest__open_disable_zapping ` 