### PR TITLE
save evaluations groupandfocal in dataset

### DIFF
--- a/baselines/evaluation/evaluate.py
+++ b/baselines/evaluation/evaluate.py
@@ -135,6 +135,7 @@ if __name__ == "__main__":
     print("evaluate_on_scenario=False. Evaluating on substrate found in the config file provided.")
   
   results, scenario = run_evaluation(args)
+  results.to_csv(f'{args.config_dir}/results_evals.csv',index=False)
   print(f"Results for {scenario}: ")
   with pd.option_context('display.max_rows', None, 'display.max_columns', None):
       print(results)


### PR DESCRIPTION
### What does this PR do ?
Creates a `.csv` file that save evaluations to a dataset.
It allows us to do evals in group and focal populations


Hello @whymath ! I´ll provide you with the command for testing this.
The quicker way is not to produce video 

The command comes as follows.
` python evaluate.py --config_dir '...path/.../PPO_meltingpot_f9685_00000_0_2024-05-03_21-33-10' --policies_dir '..path/.../PPO_meltingpot_6fb20_00000_0_2024-05-04_13-57-09/checkpoint_000033/policies' --eval_on_scenario=True --scenario commons_harvest__open_0`

So basically is taking a trained folder and pass the `--policies_dir`  and `--eval_on_scenario=True --scenario commons_harvest__open_0` ( Evaluation scenario ) You don´t need to pass the video flag.
Something like this should be printed in console, and a `.csv` file shall be saved

```
  background_player_returns  focal_per_capita_return  \
0 [34.0, 56.0, 32.0...               34.285714
1 [29.0, 34.0, 34.0...                38.000000

                                  focal_player_names  \
0  [agent_3, agent_1, agent_1, agent_1, agent_5, ...
1  [agent_2, agent_0, agent_1, agent_1, agent_2, ...

                         focal_player_returns  \
0  [37.0, 38.0, 34.0, 37.0, 38.0, 32.0, 24.0]
1  [64.0, 52.0, 11.0, 46.0, 39.0, 21.0, 33.0]

                                          video_path
0  /Users/gema/ray_results/commons_harvest__open/...
1  /Users/gema/ray_results/commons_harvest__open/...
```



