### PR TITLE
Apple tracking

### DIFF
--- a/meltingpot/configs/substrates/commons_harvest__farmer.py
+++ b/meltingpot/configs/substrates/commons_harvest__farmer.py
@@ -55,6 +55,8 @@ import numpy as np
 
 # Warning: setting `_ENABLE_DEBUG_OBSERVATIONS = True` may cause slowdown.
 _ENABLE_DEBUG_OBSERVATIONS = False
+# Prints out when an avatar eats an apple.
+_ENABLE_EAT_PRINTING = False
 
 APPLE_RESPAWN_RADIUS = 2.0
 REGROWTH_PROBABILITIES = [0.0, 0.0025, 0.005, 0.025]
@@ -369,6 +371,7 @@ def create_apple_prefab(regrowth_radius=-1.0,  # pylint: disable=dangerous-defau
                   "liveState": "apple",
                   "waitState": "appleWait",
                   "rewardForEating": 1.0,
+                  "printEat": _ENABLE_EAT_PRINTING,
               }
           },
           {

--- a/meltingpot/configs/substrates/commons_harvest__private_property.py
+++ b/meltingpot/configs/substrates/commons_harvest__private_property.py
@@ -53,6 +53,8 @@ import numpy as np
 
 # Warning: setting `_ENABLE_DEBUG_OBSERVATIONS = True` may cause slowdown.
 _ENABLE_DEBUG_OBSERVATIONS = False
+# Prints out when an avatar eats an apple.
+_ENABLE_EAT_PRINTING = False
 
 APPLE_RESPAWN_RADIUS = 2.0
 REGROWTH_PROBABILITIES = [0.0, 0.0025, 0.005, 0.025]
@@ -376,6 +378,7 @@ def create_apple_prefab(regrowth_radius=-1.0,  # pylint: disable=dangerous-defau
                   "liveState": "apple",
                   "waitState": "appleWait",
                   "rewardForEating": 1.0,
+                  "printEat": _ENABLE_EAT_PRINTING,
               }
           },
           {

--- a/meltingpot/lua/modules/component_library.lua
+++ b/meltingpot/lua/modules/component_library.lua
@@ -958,12 +958,14 @@ function Edible:__init__(kwargs)
       {'liveState', args.stringType},
       {'waitState', args.stringType},
       {'rewardForEating', args.numberType},
+      {'printEat', args.booleanType},
   })
   Edible.Base.__init__(self, kwargs)
 
   self._config.liveState = kwargs.liveState
   self._config.waitState = kwargs.waitState
   self._config.rewardForEating = kwargs.rewardForEating
+  self._config.printEat = kwargs.printEat
 end
 
 function Edible:reset()
@@ -995,6 +997,9 @@ function Edible:onEnter(enteringGameObject, contactName)
       avatarComponent:addReward(self._config.rewardForEating)
       events:add('edible_consumed', 'dict',
                  'player_index', avatarComponent:getIndex())  -- int
+      if self._printEat then
+        print("Avatar " .. avatarComponent:getIndex() .. " consumed apple!")
+      end
       -- Change the edible to its wait (disabled) state.
       self.gameObject:setState(self._waitState)
     end

--- a/parse_edible_output.sh
+++ b/parse_edible_output.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if at least the input source (program command or input file) is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <evaluation command | input_file> [output_file]"
+    exit 1
+fi
+
+INPUT_SOURCE="$1"
+OUTPUT_FILE="${2:-avatar_apple_consumption.csv}"
+
+# associative array
+declare -A avatar_counts
+
+process_input() {
+    # internal field seperator, line by line
+    while IFS= read -r line; do
+        if [[ $line =~ Avatar\ ([0-9]+)\ consumed\ apple! ]]; then
+            avatar_index="${BASH_REMATCH[1]}"
+            ((avatar_counts[$avatar_index]++))
+        fi
+    done
+}
+
+# file or a command
+if [[ -f "$INPUT_SOURCE" ]]; then
+    # from file
+    process_input < "$INPUT_SOURCE"
+else
+  # from STDOUT
+  $INPUT_SOURCE | process_input
+fi
+
+echo "Avatar,Count" > "$OUTPUT_FILE"
+for avatar in "${!avatar_counts[@]}"; do
+    echo "$avatar,${avatar_counts[$avatar]}" >> "$OUTPUT_FILE"
+done
+
+echo "Results have been written to $OUTPUT_FILE"


### PR DESCRIPTION
Enables apple tracking by simply printing out when an avatar eats an apple, and includes a script for parsing STDOUT and collecting the results into a csv file. Updated the configuration for two substrates to support it, but substrate configurations can easily be updated to include it. Not the best solution for apple tracking, but it does work. Unfortunately it might slow down evaluations due to the print spam.